### PR TITLE
Switch to simple parsing + add checkpoint argument

### DIFF
--- a/requirements_raven.txt
+++ b/requirements_raven.txt
@@ -2,3 +2,4 @@ nibabel==4.0.2
 Pillow==9.3.0
 wandb==0.14.0
 pytest==7.2.2
+simple-parsing>=0.1.2

--- a/scripts/slurm/3-training.py
+++ b/scripts/slurm/3-training.py
@@ -167,16 +167,21 @@ if __name__ == "__main__":
         "--no_randomise_res", help="Don't randomise resolution.", action="store_true"
     )
 
-    # wandb
     parser.add_argument(
-        "--wandb", help="Log training to WandB.", action="store_true"
+        "--checkpoint",
+        type=str,
+        help="File path to a checkpoint to resume training.",
+        default=None,
     )
+
+    # wandb
+    parser.add_argument("--wandb", help="Log training to WandB.", action="store_true")
     parser.add_argument(
         "--wandb_log_freq",
         type=int_or_str,
         help="Log frequency for the WandB callback. If 'epoch', logs metrics at the end of each epoch. "
-            "If 'batch', logs metrics at the end of each batch. If an integer, logs metrics at the end of that "
-            "many batches. Defaults to 'epoch'.",
+        "If 'batch', logs metrics at the end of each batch. If an integer, logs metrics at the end of that "
+        "many batches. Defaults to 'epoch'.",
         default="epoch",
     )
 
@@ -212,6 +217,7 @@ if __name__ == "__main__":
         wl2_epochs=args.wl2_epochs,
         dice_epochs=args.dice_epochs,
         steps_per_epoch=args.steps_per_epoch,
+        checkpoint=args.checkpoint,
         wandb=args.wandb,
-        wandb_log_freq=args.wandb_log_freq
+        wandb_log_freq=args.wandb_log_freq,
     )

--- a/scripts/slurm/3-training.py
+++ b/scripts/slurm/3-training.py
@@ -1,4 +1,8 @@
 from argparse import ArgumentParser
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import simple_parsing
 
 from SynthSeg.training import training
 
@@ -10,182 +14,73 @@ def int_or_str(arg: str):
         return arg
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser()
-
-    # TODO: copy doc strings from train function to argument help
-    # path training label maps
-    parser.add_argument(
-        "--path_training_label_maps",
-        type=str,
-        help="Output path",
-        default="../../data/training_label_maps",
+# TODO: copy doc strings from train function to argument help, maybe separate into different data classes ...
+@dataclass
+class Options:
+    path_training_label_maps: str = (
+        "../../data/training_label_maps"  # Label maps for the training
     )
-    parser.add_argument(
-        "--path_model_dir", type=str, help="Output path", default="./output_tutorials_3"
-    )
-    parser.add_argument("--batchsize", type=int, help="Batch size", default=1)
+    path_model_dir: str = "./output_tutorials_3"  # Output path
 
     # architecture parameters
-    parser.add_argument(
-        "--n_levels", type=int, help="Number of resolution levels", default=5
-    )
-    parser.add_argument(
-        "--nb_conv_per_level",
-        type=int,
-        help="Number of convolution per level",
-        default=2,
-    )
-    parser.add_argument(
-        "--conv_size",
-        type=int,
-        help="Size of the convolution kernel (e.g. 3x3x3)",
-        default=3,
-    )
-    parser.add_argument(
-        "--unet_feat_count",
-        type=int,
-        help="Number of feature maps after the first convolution",
-        default=24,
-    )
-    parser.add_argument(
-        "--activation",
-        type=str,
-        help="Activation for all convolution layers except the last, which will use softmax regardless",
-        default="elu",
-    )
-    parser.add_argument(
-        "--feat_multiplier",
-        type=int,
-        help="If this is set to 1, we will keep the number of feature maps constant throughout the network; "
-        "2 will double them (resp. half) after each max-pooling (resp. upsampling); 3 will triple them, etc.",
-        default=2,
-    )
+
+    n_levels: int = 5  # Number of resolution levels
+    nb_conv_per_level: int = 2  # Number of convolution per level
+    conv_size: int = 3  # Size of the convolution kernel (e.g. 3x3x3)
+    unet_feat_count: int = 24  # Number of feature maps after the first convolution
+    activation: str = "elu"  # Activation for all convolution layers except the last, which will use softmax regardless
+    feat_multiplier: int = 2  # If this is set to 1, we will keep the number of feature maps constant throughout the network; 2 will double them (resp. half) after each max-pooling (resp. upsampling); 3 will triple them, etc.
 
     # training parameters
-    parser.add_argument(
-        "--lr",
-        type=float,
-        help="learning rate",
-        default=1e-4,
-    )
-    parser.add_argument(
-        "--wl2_epochs",
-        type=int,
-        help="Number of pre-training epochs with wl2 metric w.r.t. the layer before the softmax.",
-        default=1,
-    )
-    parser.add_argument(
-        "--dice_epochs",
-        type=int,
-        help="Number of training epochs.",
-        default=100,
-    )
-    parser.add_argument(
-        "--steps_per_epoch",
-        type=int,
-        help="Number of iterations per epoch.",
-        default=5000,
-    )
+
+    batchsize: int = 1  # Batch size
+    lr: float = 1e-4  # learning rate
+    wl2_epochs: int = 1  # Number of pre-training epochs with wl2 metric w.r.t. the layer before the softmax
+    dice_epochs: int = 100  # Number of training epochs
+    steps_per_epoch: int = 5000  # Number of iterations per epoch
 
     # generation and segmentation labels
-    parser.add_argument(
-        "--path_generation_labels",
-        type=str,
-        help="Path to generation labels.",
-        default="../../data/labels_classes_priors/generation_labels.npy",
-    )
-    parser.add_argument(
-        "--n_neutral_labels", type=int, help="Number of neutral labels.", default=18
-    )
-    parser.add_argument(
-        "--path_segmentation_labels",
-        type=str,
-        help="Path to segmentation labels.",
-        default="../../data/labels_classes_priors/synthseg_segmentation_labels.npy",
+
+    path_generation_labels: str = "../../data/labels_classes_priors/generation_labels.npy"  # Path to generation labels
+    n_neutral_labels: int = 18  # Number of neutral labels
+    path_segmentation_labels: str = (
+        "../../data/labels_classes_priors/synthseg_segmentation_labels.npy"
     )
 
-    # shape and resolution of the outputs
-    parser.add_argument(
-        "--target_res", type=int, help="Target resolution.", default=None
-    )
-    parser.add_argument("--output_shape", type=int, help="Output shape.", default=160)
-    parser.add_argument("--n_channels", type=int, help="Number of channels.", default=1)
+    # shape and resolution of the output
+
+    target_res: Optional[int] = None  # Target resolution
+    output_shape: int = 160  # Output shape
+    n_channels: int = 1  # Number of channels
 
     # GMM sampling
-    parser.add_argument(
-        "--prior_distributions",
-        type=str,
-        help="The prior distribution.",
-        default="uniform",
-    )
-    parser.add_argument(
-        "--path_generation_classes",
-        type=str,
-        help="Path to the generation classes.",
-        default="../../data/labels_classes_priors/generation_classes.npy",
-    )
+
+    prior_distributions: str = "uniform"  # The prior distribution
+    path_generation_classes: str = "../../data/labels_classes_priors/generation_classes.npy"  # Path to the generation classes
 
     # spatial deformation parameters
-    parser.add_argument("--no_flipping", help="Don't flip.", action="store_true")
-    parser.add_argument(
-        "--scaling_bounds",
-        type=float,
-        help="Scaling bounds.",
-        default=0.2,
-    )
-    parser.add_argument(
-        "--rotation_bounds",
-        type=int,
-        help="Rotation bounds.",
-        default=15,
-    )
-    parser.add_argument(
-        "--shearing_bounds",
-        type=float,
-        help="Shearing bounds.",
-        default=0.012,
-    )
-    parser.add_argument(
-        "--translation_bounds", help="Translation bounds.", action="store_true"
-    )
-    parser.add_argument(
-        "--nonlin_std",
-        type=float,
-        help="Nonlin std.",
-        default=4.0,
-    )
-    parser.add_argument(
-        "--bias_field_std",
-        type=float,
-        help="Bias field std.",
-        default=0.7,
-    )
+
+    flipping: bool = True  # Flip?
+    scaling_bounds: Union[float, bool] = 0.2  # Scaling bounds
+    rotation_bounds: int = 15  # Rotation bounds
+    shearing_bounds: float = 0.012  # Shearing bounds
+    translation_bounds: Union[float, bool] = False  # Translation bounds
+    nonlin_std: float = 4.0  # Nonlin std.
+    bias_field_std: float = 0.7  # Bias field std.
 
     # acquisition resolution parameters
-    parser.add_argument(
-        "--no_randomise_res", help="Don't randomise resolution.", action="store_true"
-    )
 
-    parser.add_argument(
-        "--checkpoint",
-        type=str,
-        help="File path to a checkpoint to resume training.",
-        default=None,
-    )
+    randomise_res: bool = True  # Don't randomise resolution
+    checkpoint: Optional[str] = None  # Path of an already saved model to load before starting the training.
 
-    # wandb
-    parser.add_argument("--wandb", help="Log training to WandB.", action="store_true")
-    parser.add_argument(
-        "--wandb_log_freq",
-        type=int_or_str,
-        help="Log frequency for the WandB callback. If 'epoch', logs metrics at the end of each epoch. "
-        "If 'batch', logs metrics at the end of each batch. If an integer, logs metrics at the end of that "
-        "many batches. Defaults to 'epoch'.",
-        default="epoch",
-    )
+    # WandB
 
-    args = parser.parse_args()
+    wandb_log_freq: Union[int, str] = "epoch"  # Log frequency for the WandB callback. If 'epoch', logs metrics at the end of each epoch. If 'batch', logs metrics at the end of each batch. If an integer, logs metrics at the end of that many batches. Defaults to 'epoch'."
+    wandb: bool = False  # Log training to WandB
+
+
+if __name__ == "__main__":
+    args: Options = simple_parsing.parse(Options)
 
     training(
         args.path_training_label_maps,
@@ -199,13 +94,13 @@ if __name__ == "__main__":
         output_shape=args.output_shape,
         prior_distributions=args.prior_distributions,
         generation_classes=args.path_generation_classes,
-        flipping=not args.no_flipping,
+        flipping=not args.flipping,
         scaling_bounds=args.scaling_bounds,
         rotation_bounds=args.rotation_bounds,
         shearing_bounds=args.shearing_bounds,
         translation_bounds=args.translation_bounds,
         nonlin_std=args.nonlin_std,
-        randomise_res=not args.no_randomise_res,
+        randomise_res=not args.randomise_res,
         bias_field_std=args.bias_field_std,
         n_levels=args.n_levels,
         nb_conv_per_level=args.nb_conv_per_level,


### PR DESCRIPTION
This PR exposes the checkpoint argument to the slurm training script. It also switches to simple parsing.

I also added a dummy version of the `brain_generator_options.py` file which is missing. Maybe the issue is that we have this entry in the gitignore file
```
SynthSeg/brain_generator_*
```
and you have a version of this file locally?