### PR TITLE
Fix TF deprecation of `dtype` argument

### DIFF
--- a/SynthSeg/predict_synthseg.py
+++ b/SynthSeg/predict_synthseg.py
@@ -776,7 +776,7 @@ class MakeShape(KL.Layer):
         super(MakeShape, self).build(input_shape)
 
     def call(self, inputs, **kwargs):
-        return tf.map_fn(self._single_process, inputs, dtype=tf.int32)
+        return tf.map_fn(self._single_process, inputs, fn_output_signature=tf.int32)
 
     def _single_process(self, inputs):
 

--- a/SynthSeg/training_qc.py
+++ b/SynthSeg/training_qc.py
@@ -463,7 +463,7 @@ class SimulatePartialFOV(tf.keras.layers.Layer):
             mask_idx_sup = mask_idx_sup_tmp
 
         # mask input labels
-        mask = tf.map_fn(self._single_build_mask, [x, mask_idx_inf, mask_idx_sup], tf.int32)
+        mask = tf.map_fn(self._single_build_mask, [x, mask_idx_inf, mask_idx_sup], fn_output_signature=tf.int32)
         x = tf.keras.backend.switch(tf.squeeze(tf.keras.backend.greater(tf.random.uniform([1], 0, 1), 1 - self.prob_mask)), x * mask, x)
 
         # compute dice score for each label value
@@ -476,7 +476,7 @@ class SimulatePartialFOV(tf.keras.layers.Layer):
 
         # crop input labels
         if self.crop_max_val > 0:
-            x_cropped = tf.map_fn(self._single_slice, [x, crop_idx_inf], dtype=tf.float32)
+            x_cropped = tf.map_fn(self._single_slice, [x, crop_idx_inf], fn_output_signature=tf.float32)
         else:
             x_cropped = x
 

--- a/ext/lab2im/layers.py
+++ b/ext/lab2im/layers.py
@@ -250,13 +250,13 @@ class RandomCrop(tf.keras.layers.Layer):
 
         # if one input only is provided, performs the cropping directly
         if not self.several_inputs:
-            return tf.map_fn(self._single_slice, inputs, dtype=inputs.dtype)
+            return tf.map_fn(self._single_slice, inputs, fn_output_signature=inputs.dtype)
 
         # otherwise we concatenate all inputs before cropping, so that they are all cropped at the same location
         else:
             types = [v.dtype for v in inputs]
             inputs = tf.concat([tf.cast(v, 'float32') for v in inputs], axis=-1)
-            inputs = tf.map_fn(self._single_slice, inputs, dtype=tf.float32)
+            inputs = tf.map_fn(self._single_slice, inputs, fn_output_signature=tf.float32)
             inputs = tf.split(inputs, self.list_n_channels, axis=-1)
             return unpack_singleton([tf.cast(v, t) for (t, v) in zip(types, inputs)])
 
@@ -395,13 +395,13 @@ class RandomFlip(tf.keras.layers.Layer):
         swapped_inputs = list()
         for i in range(len(inputs)):
             if self.swap_labels[i]:
-                swapped_inputs.append(tf.map_fn(self._single_swap, [inputs[i], rand_flip], dtype=types[i]))
+                swapped_inputs.append(tf.map_fn(self._single_swap, [inputs[i], rand_flip], fn_output_signature=types[i]))
             else:
                 swapped_inputs.append(inputs[i])
 
         # flip inputs and convert them back to their original type
         inputs = tf.concat([tf.cast(v, 'float32') for v in swapped_inputs], axis=-1)
-        inputs = tf.map_fn(self._single_flip, [inputs, rand_flip], dtype=tf.float32)
+        inputs = tf.map_fn(self._single_flip, [inputs, rand_flip], fn_output_signature=tf.float32)
         inputs = tf.split(inputs, self.list_n_channels, axis=-1)
 
         return unpack_singleton([tf.cast(v, t) for (t, v) in zip(types, inputs)])
@@ -479,12 +479,12 @@ class SampleConditionalGMM(tf.keras.layers.Layer):
         means = tf.concat([inputs[1][..., i] for i in range(self.n_channels)], 1)
         tile_shape = tf.concat([batch, tf.convert_to_tensor([1, ], dtype='int32')], axis=0)
         means = tf.tile(tf.expand_dims(tf.scatter_nd(tmp_indices, means, self.shape), 0), tile_shape)
-        means_map = tf.map_fn(lambda x: tf.gather(x[0], x[1]), [means, labels], dtype=tf.float32)
+        means_map = tf.map_fn(lambda x: tf.gather(x[0], x[1]), [means, labels], fn_output_signature=tf.float32)
 
         # same for stds
         stds = tf.concat([inputs[2][..., i] for i in range(self.n_channels)], 1)
         stds = tf.tile(tf.expand_dims(tf.scatter_nd(tmp_indices, stds, self.shape), 0), tile_shape)
-        stds_map = tf.map_fn(lambda x: tf.gather(x[0], x[1]), [stds, labels], dtype=tf.float32)
+        stds_map = tf.map_fn(lambda x: tf.gather(x[0], x[1]), [stds, labels], fn_output_signature=tf.float32)
 
         return stds_map * tf.random.normal(tf.shape(labels)) + means_map
 
@@ -806,9 +806,9 @@ class DynamicGaussianBlur(tf.keras.layers.Layer):
         kernels = l2i_et.gaussian_kernel(sigma, self.max_sigma, self.blur_range, self.separable)
         if self.separable:
             for kernel in kernels:
-                image = tf.map_fn(self._single_blur, [image, kernel], dtype=tf.float32)
+                image = tf.map_fn(self._single_blur, [image, kernel], fn_output_signature=tf.float32)
         else:
-            image = tf.map_fn(self._single_blur, [image, kernels], dtype=tf.float32)
+            image = tf.map_fn(self._single_blur, [image, kernels], fn_output_signature=tf.float32)
         return image
 
     def _single_blur(self, inputs):
@@ -935,7 +935,7 @@ class MimicAcquisition(tf.keras.layers.Layer):
         inshape_tens = tf.tile(tf.expand_dims(tf.convert_to_tensor(self.inshape[:-1]), 0), tile_shape)
         inshape_tens = l2i_et.expand_dims(inshape_tens, axis=[1] * self.n_dims)
         down_loc = tf.keras.backend.clip(down_loc, 0., tf.cast(inshape_tens, 'float32'))
-        vol = tf.map_fn(self._single_down_interpn, [vol, down_loc], tf.float32)
+        vol = tf.map_fn(self._single_down_interpn, [vol, down_loc], fn_output_signature=tf.float32)
 
         # add noise
         if self.noise_std > 0:
@@ -946,7 +946,7 @@ class MimicAcquisition(tf.keras.layers.Layer):
         # upsample
         up_loc = tf.tile(self.up_grid, tf.concat([batchsize, tf.ones([self.n_dims + 1], dtype='int32')], axis=0))
         up_loc = tf.cast(up_loc, 'float32') / l2i_et.expand_dims(up_zoom_factor, axis=[1] * self.n_dims)
-        vol = tf.map_fn(self._single_up_interpn, [vol, up_loc], tf.float32)
+        vol = tf.map_fn(self._single_up_interpn, [vol, up_loc], fn_output_signature=tf.float32)
 
         # return upsampled volume
         if not self.build_dist_map:
@@ -1208,7 +1208,7 @@ class IntensityAugmentation(tf.keras.layers.Layer):
             split_rand_invert = tf.split(rand_invert, [1] * self.n_channels, axis=-1)
             inverted_channel = list()
             for (channel, invert) in zip(split_channels, split_rand_invert):
-                inverted_channel.append(tf.map_fn(self._single_invert, [channel, invert], dtype=channel.dtype))
+                inverted_channel.append(tf.map_fn(self._single_invert, [channel, invert], fn_output_signature=channel.dtype))
             inputs = tf.concat(inverted_channel, -1)
 
         return inputs
@@ -1703,12 +1703,12 @@ class RandomDilationErosion(tf.keras.layers.Layer):
             if (self.max_factor == self.max_factor_dilate) | (self.operation != 'random'):
                 dist_threshold = tf.random.uniform(shape, minval=self.min_factor, maxval=self.max_factor, dtype='int32')
             else:
-                dist_threshold = tf.cast(tf.map_fn(self._sample_factor, [prob], dtype=tf.float32), dtype='int32')
+                dist_threshold = tf.cast(tf.map_fn(self._sample_factor, [prob], fn_output_signature=tf.float32), dtype='int32')
         kernel = l2i_et.unit_kernel(dist_threshold, self.n_dims, max_dist_threshold=self.max_factor)
 
         # convolve input mask with kernel according to given probability
         mask = tf.cast(tf.cast(inputs, dtype='bool'), dtype='float32')
-        mask = tf.map_fn(self._single_blur, [mask, kernel, prob], dtype=tf.float32)
+        mask = tf.map_fn(self._single_blur, [mask, kernel, prob], fn_output_signature=tf.float32)
         mask = tf.cast(mask, 'bool')
 
         if self.return_mask:

--- a/ext/neuron/layers.py
+++ b/ext/neuron/layers.py
@@ -159,10 +159,10 @@ class SpatialTransformer(tf.keras.layers.Layer):
         if len(trf) == 1:
             trf = trf[0]
             if self.is_affine[0]:
-                trf = tf.map_fn(lambda x: self._single_aff_to_shift(x, vol.shape[1:-1]), trf, dtype=tf.float32)
+                trf = tf.map_fn(lambda x: self._single_aff_to_shift(x, vol.shape[1:-1]), trf, fn_output_signature=tf.float32)
         # combine non linear and affine to obtain a single deformation field
         elif len(trf) == 2:
-            trf = tf.map_fn(lambda x: self._non_linear_and_aff_to_shift(x, vol.shape[1:-1]), trf, dtype=tf.float32)
+            trf = tf.map_fn(lambda x: self._non_linear_and_aff_to_shift(x, vol.shape[1:-1]), trf, fn_output_signature=tf.float32)
 
         # prepare location shift
         if self.indexing == 'xy':  # shift the first two dimensions
@@ -172,9 +172,9 @@ class SpatialTransformer(tf.keras.layers.Layer):
 
         # map transform across batch
         if self.single_transform:
-            return tf.map_fn(self._single_transform, [vol, trf[0, :]], dtype=tf.float32)
+            return tf.map_fn(self._single_transform, [vol, trf[0, :]], fn_output_signature=tf.float32)
         else:
-            return tf.map_fn(self._single_transform, [vol, trf], dtype=tf.float32)
+            return tf.map_fn(self._single_transform, [vol, trf], fn_output_signature=tf.float32)
 
     def _single_aff_to_shift(self, trf, volshape):
         if len(trf.shape) == 1:  # go from vector to matrix
@@ -269,7 +269,7 @@ class VecInt(tf.keras.layers.Layer):
             assert self.out_time_pt is None, 'out_time_pt should be None if providing batch_based out_time_pt'
 
         # map transform across batch
-        out = tf.map_fn(self._single_int, [loc_shift] + inputs[1:], dtype=tf.float32)
+        out = tf.map_fn(self._single_int, [loc_shift] + inputs[1:], fn_output_signature=tf.float32)
         out.set_shape(inputs[0].shape)
         return out
 
@@ -399,7 +399,7 @@ class Resize(tf.keras.layers.Layer):
             self.size0 = [int(self.inshape[f+1] * self.zoom_factor0[f]) for f in range(self.ndims)]
 
         # map transform across batch
-        return tf.map_fn(self._single_resize, vol, dtype=vol.dtype)
+        return tf.map_fn(self._single_resize, vol, fn_output_signature=vol.dtype)
 
     def compute_output_shape(self, input_shape):
 


### PR DESCRIPTION
The `dtype` argument for `tf.map_fn` is deprecated (a planned for removal today). I believe the fix is just to use `fn_output_signature` instead like this:

```python
tf.map_fn(self._single_transform, [vol, trf], fn_output_signature=tf.float32)
```

I hope I caught all call-sites.