### PR TITLE
Fix/unify options design

### DIFF
--- a/SynthSeg/analysis/mpm_analysis.py
+++ b/SynthSeg/analysis/mpm_analysis.py
@@ -177,9 +177,9 @@ def main():
     gen_opts.n_neutral_labels = 18
 
     # Write out the analysis result as a template brain generator config.
-    output_file = os.path.join(options.output_dir, "generator.yml")
-    logger.info(f"Writing generator config to {output_file}")
-    gen_opts.save_yaml(output_file, default_flow_style=None)
+    output_file_generator = os.path.join(options.output_dir, "_generator.yml")
+    logger.info(f"Writing generator config to {output_file_generator}")
+    gen_opts.save_yaml(output_file_generator, default_flow_style=None)
 
 
 if __name__ == '__main__':

--- a/SynthSeg/brain_generator_options.py
+++ b/SynthSeg/brain_generator_options.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from simple_parsing.helpers import Serializable
 from dataclasses import dataclass
 

--- a/SynthSeg/brain_generator_options.py
+++ b/SynthSeg/brain_generator_options.py
@@ -210,7 +210,7 @@ class GeneratorOptions(Serializable, OptionsBase):
 
     """
 
-    data_res: Union[None, int, List[int], str] = None
+    data_res: Union[None, float, List[float], str] = None
     """
     Specific acquisition resolution to mimic, as opposed to random resolution sampled
     when randomise_res is True. This triggers a blurring which mimics the acquisition resolution, but down-sampling

--- a/SynthSeg/brain_generator_options.py
+++ b/SynthSeg/brain_generator_options.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 from simple_parsing.helpers import Serializable
 from dataclasses import dataclass
-import numpy as np
 
 from .option_types import *
-from .option_utils import get_absolute_path
+from .options_base import OptionsBase
 
 
 @dataclass
-class GeneratorOptions(Serializable):
+class GeneratorOptions(Serializable, OptionsBase):
     """
     Options for synthesizing brain MRI images from label maps
     """
@@ -249,33 +248,25 @@ class GeneratorOptions(Serializable):
     gradient (computed with Sobel kernels).
     """
 
-    def with_absolute_paths(self, reference_file: str):
-        """
-        Adds absolute paths to specified file paths in the GeneratorOptions object.
-        Since all string properties are supposed to be paths, we just iterate through all properties
-        and change the ones that are strings.
+    @staticmethod
+    def get_np_list_options() -> List[str]:
+        return [
+            "generation_labels",
+            "output_labels",
+            "generation_classes",
+            "target_res",
+            "prior_means",
+            "prior_stds",
+            "output_shape",
+            "thickness",
+            "data_res",
+            "output_div_by_n",
+            "scaling_bounds",
+            "rotation_bounds",
+            "shearing_bounds",
+            "translation_bounds"
+        ]
 
-        Args:
-            reference_file (str): The reference file to be used for generating absolute paths.
-
-        Returns:
-            GeneratorOptions: A copy of the GeneratorOptions object with absolute paths added.
-        """
-        copy = GeneratorOptions()
-        excluded_properties = ["prior_distributions"]
-        for key, value in vars(self).items():
-            if isinstance(value, str) and key not in excluded_properties:
-                setattr(copy, key, get_absolute_path(value, reference_file))
-            else:
-                setattr(copy, key, value)
-        return copy
-
-    def convert_lists_to_numpy(self):
-        copy = GeneratorOptions()
-        np_properties = ["generation_labels", "output_labels", "generation_classes", "prior_means", "prior_stds"]
-        for key, value in vars(self).items():
-            if key in np_properties and isinstance(value, list):
-                setattr(copy, key, np.array(value))
-            else:
-                setattr(copy, key, value)
-        return copy
+    @staticmethod
+    def get_non_path_string_options() -> List[str]:
+        return ["prior_distributions"]

--- a/SynthSeg/option_types.py
+++ b/SynthSeg/option_types.py
@@ -1,9 +1,16 @@
 from simple_parsing.helpers.serialization import register_decoding_fn
-from typing import Optional, Union, List
+from typing import Union, List, Optional
 
 
 def decode_boolean_float_or_list(raw_value):
     if isinstance(raw_value, (float, bool, list)):
+        return raw_value
+    else:
+        raise RuntimeError(f"Could not decode JSON value {raw_value}")
+
+
+def decode_none_str_float_list(raw_value):
+    if isinstance(raw_value, (str, float, list)):
         return raw_value
     else:
         raise RuntimeError(f"Could not decode JSON value {raw_value}")
@@ -35,6 +42,7 @@ def decode_none_str_list(raw_value):
 
 
 register_decoding_fn(Union[bool, float, List[float]], decode_boolean_float_or_list)
+register_decoding_fn(Union[None, str, List[float], List[List[float]]], decode_none_str_float_list)
 register_decoding_fn(Union[bool, float, str], decode_float_str_bool)
 register_decoding_fn(Union[None, str, int, List[int]], decode_none_str_int_list)
 register_decoding_fn(Union[None, str, List[int]], decode_none_str_list)

--- a/SynthSeg/options_base.py
+++ b/SynthSeg/options_base.py
@@ -1,0 +1,60 @@
+import numpy as np
+from typing import List
+
+from SynthSeg.option_utils import get_absolute_path
+
+
+class OptionsBase:
+    """
+    Base class for options. Derived classes must provide overrides for
+    `get_np_list_options` and `get_non_path_string_options`!
+    """
+
+    @staticmethod
+    def get_np_list_options() -> List[str]:
+        """
+        Provides names of attributes that should be converted to numpy arrays.
+        This method should be overriden in the derived class.
+        """
+        return []
+
+    @staticmethod
+    def get_non_path_string_options() -> List[str]:
+        """
+        Provides names of attributes that are strings, but are not paths.
+        These attributes will not be converted to absolute paths.
+        """
+        return []
+
+    def with_absolute_paths(self, reference_file: str):
+        """
+        Converts path attributes to absolute paths using a reference file.
+
+        Args:
+            reference_file (str): The reference file to be used for generating absolute paths.
+
+        Returns:
+            A copy of the object with absolute paths added.
+        """
+        copy = self.__class__()
+        for key, value in vars(self).items():
+            if isinstance(value, str) and key not in self.__class__.get_non_path_string_options():
+                setattr(copy, key, get_absolute_path(value, reference_file))
+            else:
+                setattr(copy, key, value)
+        return copy
+
+    def convert_lists_to_numpy(self):
+        """
+        Converts specific options from normal lists to numpy arrays.
+
+        Returns:
+            A copy of the instance with number lists converted to numpy arrays.
+        """
+        copy = self.__class__()
+        for key, value in vars(self).items():
+            if key in self.__class__.get_np_list_options() and isinstance(value, list):
+                setattr(copy, key, np.array(value))
+            else:
+                setattr(copy, key, value)
+        return copy

--- a/SynthSeg/training_options.py
+++ b/SynthSeg/training_options.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 from simple_parsing.helpers.serialization import Serializable
 
 from .option_types import *
-from .option_utils import get_absolute_path
+from .options_base import OptionsBase
 
 
 @dataclass
-class TrainingOptions(Serializable):
+class TrainingOptions(Serializable, OptionsBase):
     labels_dir: str = "../../data/training_label_maps"
     """
     Path of folder with all input label maps, or to a single label map (if only one training example)
@@ -368,28 +368,32 @@ class TrainingOptions(Serializable):
     See https://www.tensorflow.org/guide/distributed_training for more information. 
     """
 
-    def with_absolute_paths(self, reference_file: str):
-        """
-        Adds absolute paths to specified file paths in the TrainingOptions object.
-        We just iterate through all properties and change the ones that are supposed to be paths.
+    @staticmethod
+    def get_np_list_options() -> List[str]:
+        return [
+            "generation_labels",
+            # "output_labels", TODO: David, why is that not in the training options?
+            "generation_classes",
+            "prior_means",
+            "prior_stds",
+            "input_shape",
+            "target_res",
+            "output_shape",
+            "thickness",
+            "data_res",
+            # "output_div_by_n", TODO: See above comment
+            "scaling_bounds",
+            "rotation_bounds",
+            "shearing_bounds",
+            "translation_bounds"
+        ]
 
-        Args:
-            reference_file (str): The reference file to be used for generating absolute paths.
-
-        Returns:
-            TrainingOptions: A copy of the TrainingOptions object with absolute paths added.
-        """
-        copy = TrainingOptions()
-        non_path_properties = [
+    @staticmethod
+    def get_non_path_string_options() -> List[str]:
+        return [
             "activation",
             "prior_distributions",
             "wandb_log_freq",
             "compression_type",
             "strategy"
         ]
-        for key, value in vars(self).items():
-            if isinstance(value, str) and key not in non_path_properties:
-                setattr(copy, key, get_absolute_path(value, reference_file))
-            else:
-                setattr(copy, key, value)
-        return copy

--- a/SynthSeg/training_options.py
+++ b/SynthSeg/training_options.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from simple_parsing.helpers.serialization import Serializable
 
-from .option_types import *
 from .options_base import OptionsBase
+from .option_types import *
 
 
 @dataclass
@@ -101,8 +101,7 @@ class TrainingOptions(Serializable, OptionsBase):
     Can either be 'uniform', or 'normal'. Default is 'uniform'.
     """
 
-    # Todo: Check how easy it is to serialize and deserialize nested integer lists
-    prior_means: Union[None, str, List[List[float]]] = None
+    prior_means: Union[None, str, List[float], List[List[float]]] = None
     """
     Hyperparameters controlling the prior distributions of the GMM means. Because
     these prior distributions are uniform or normal, they require by 2 hyperparameters. Can be a path to:
@@ -118,7 +117,7 @@ class TrainingOptions(Serializable, OptionsBase):
     Default is None, which corresponds all GMM means sampled from uniform distribution U(25, 225).
     """
 
-    prior_stds: Union[None, str, List[List[float]]] = None
+    prior_stds: Union[None, str, List[float], List[List[float]]] = None
     """
     same as prior_means but for the standard deviations of the GMM.
     Default is None, which corresponds to U(5, 25).
@@ -154,7 +153,7 @@ class TrainingOptions(Serializable, OptionsBase):
     3) False, in which case scaling is completely turned off.
     """
 
-    rotation_bounds: Union[float, str, bool] = 15.0
+    rotation_bounds: Union[int, str, bool] = 15.0
     """
     Similar to scaling_bounds but for the rotation angle, except that for case 1 the
     bounds are centred on 0 rather than 1, i.e. (0+rotation_bounds[i], 0-rotation_bounds[i]).

--- a/data/cbs/test_256_pd_r1_r2s/analysis_template.yml
+++ b/data/cbs/test_256_pd_r1_r2s/analysis_template.yml
@@ -1,0 +1,31 @@
+batchsize: 1
+bias_field_std: 0.5
+bias_scale: 0.025
+flipping: true
+generation_labels:  [ 0, 14, 15, 16, 24, 72, 85, 502, 506, 507, 508, 509, 511, 512, 514, 515, 516, 530, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 25, 26, 28, 30, 136, 137, 41, 42, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 57, 58, 60, 62, 163, 164 ]
+output_labels: [ 0, 14, 15, 16, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 0, 26, 28, 0, 0, 0, 41, 42, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 0, 58, 60, 0, 0, 0 ]
+generation_classes: [ 0, 0,  0,  0,  0,  0,  0,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+n_neutral_labels: 18
+labels_dir: ../data/training_label_maps
+data_res: null
+target_res: 0.5
+randomise_res: false
+max_res_aniso: 1.0
+max_res_iso: 1.0
+mix_prior_and_random: false
+n_channels: 2
+use_specific_stats_for_channel: true
+nonlin_scale: 0.04
+nonlin_std: 3.0
+output_div_by_n: null
+output_shape: null
+prior_distributions: uniform
+prior_means: [[0.001, 0.99, 0.49], [0.002, 1.0, 0.5], [0.001, 0.49, 0.99], [0.002, 0.5, 1.0]]
+prior_stds: [[0.000001, 0.000001, 0.000001], [0.000002, 0.000002, 0.000002], [0.000001, 0.000001, 0.000001], [0.000002, 0.000002, 0.000002]]
+return_gradients: false
+rotation_bounds: 2
+scaling_bounds: 0.02
+shearing_bounds: 0.015
+subjects_prob: null
+thickness: null
+translation_bounds: 0.0

--- a/scripts/commands/check_unet_size.py
+++ b/scripts/commands/check_unet_size.py
@@ -1,0 +1,85 @@
+import gc
+import os
+import numpy as np
+import tensorflow as tf
+from dataclasses import dataclass, field
+from typing import Optional, List
+from simple_parsing import ArgumentParser
+
+from SynthSeg.training_options import TrainingOptions
+from ext.neuron import models as nrn_models
+from SynthSeg.logging_utils import get_logger
+from SynthSeg.option_utils import get_absolute_path, project_directory
+
+logger = get_logger(os.path.basename(__file__))
+
+
+@dataclass
+class Options:
+    """
+    Commandline options for specifying the UNet
+    """
+
+    config: Optional[str] = None
+    """Path to a training config file that specifies the parameters."""
+
+    net_sizes: List[int] = field(default_factory=lambda: [256])
+
+    bits: int = 32
+    """
+    Bit size of the parameters in the neural network. Defaults to 32 for type float32 but other settings are possible.
+    """
+
+
+def main():
+    parser = ArgumentParser()
+    # noinspection PyTypeChecker
+    parser.add_arguments(Options, "general")
+    args = parser.parse_args()
+    arguments: Options = args.general
+
+    if not isinstance(arguments.config, str):
+        logger.error("You must specify a valid path to a training configuration.")
+        exit(1)
+
+    conf_file = get_absolute_path(arguments.config)
+    if isinstance(conf_file, str) and os.path.isfile(conf_file) and os.access(conf_file, os.R_OK):
+        logger.info("Loading training config from configuration file.")
+
+        # Load config and make paths within the config absolute
+        opts = TrainingOptions.load(conf_file)
+        opts = (opts
+                .with_absolute_paths(os.path.abspath(conf_file))
+                .convert_lists_to_numpy()
+                )
+    else:
+        logger.error(f"Unable to load training config from file {conf_file}")
+        exit(1)
+
+    for s in arguments.net_sizes:
+        print(f"Size: {s}")
+        unet_model = nrn_models.unet(
+            input_shape=[s, s, s, 3],
+            nb_labels=opts.n_labels,
+            nb_levels=opts.n_levels,
+            nb_conv_per_level=opts.nb_conv_per_level,
+            conv_size=opts.conv_size,
+            nb_features=opts.unet_feat_count,
+            feat_mult=opts.feat_multiplier,
+            activation=opts.activation,
+            batch_norm=-1
+        )
+        print(unet_model.summary())
+        unet_model.save("/home/patrick/tmp/unet")
+        parameter_count = unet_model.count_params()
+        bit_size = parameter_count * arguments.bits
+        megabytes = np.ceil(bit_size / (8 * 2**20))
+        logger.info(f"Megabytes: {megabytes}")
+
+        del unet_model
+        tf.keras.backend.clear_session()
+        gc.collect()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/slurm/training.py
+++ b/scripts/slurm/training.py
@@ -26,8 +26,11 @@ def main():
     args = parser.parse_args()
 
     if args.cfg_file:
-        training_options = TrainingOptions.load(args.cfg_file)
-        training_options = training_options.with_absolute_paths(os.path.abspath(args.cfg_file))
+        training_options = (TrainingOptions
+                            .load(args.cfg_file)
+                            .convert_lists_to_numpy()
+                            .with_absolute_paths(os.path.abspath(args.cfg_file))
+                            )
     else:
         training_options = args.options
 

--- a/tests/test_options_base.py
+++ b/tests/test_options_base.py
@@ -1,0 +1,55 @@
+import numpy as np
+import os
+from typing import Type
+
+from SynthSeg.brain_generator_options import GeneratorOptions
+from SynthSeg.options_base import OptionsBase
+from SynthSeg.training_options import TrainingOptions
+
+
+def test_numpy_replacement():
+    """
+    Check if the conversion from lists to numpy arrays works correctly.
+    We check both option classes and go through all the possible list types,
+    then we convert them to numpy arrays and check their type.
+    """
+    run_numpy_replacement(GeneratorOptions)
+    run_numpy_replacement(TrainingOptions)
+
+
+def test_path_replacement():
+    """
+    We check all string fields that are not explicitly excluded.
+    However, we only check if the original paths from the default instantiation are
+    relative (which it is not required to be) and if they are absolute after conversion.
+    """
+    run_path_replacement(GeneratorOptions)
+    run_numpy_replacement(TrainingOptions)
+
+
+def run_numpy_replacement(clazz: Type[OptionsBase]):
+    opts = clazz()
+    np_opts = opts.convert_lists_to_numpy()
+    list_attributes = opts.get_np_list_options()
+
+    for a in list_attributes:
+        assert hasattr(opts, a), f"Field {a} does not exist."
+        if isinstance(getattr(opts, a), list):
+            assert isinstance(getattr(np_opts, a), np.ndarray), f"List {a} is not a numpy array."
+
+
+def run_path_replacement(clazz: Type[OptionsBase]):
+    opts = clazz()
+    names = vars(opts).keys()
+    abs_opts = opts.with_absolute_paths(__file__)
+    excluded_attributes = opts.get_non_path_string_options()
+
+    for n in names:
+        assert hasattr(opts, n), f"Field {n} does not exist."
+        field = getattr(opts, n)
+        if isinstance(field, str) and n not in excluded_attributes:
+            path = field
+            abs_path = getattr(abs_opts, n)
+
+            assert not os.path.isabs(path), f"Path {n} should be relative"
+            assert os.path.isabs(abs_path), f"Path {n} is not absolute"


### PR DESCRIPTION
Since we need absolute paths and numpy-list conversion in both training and generation configs, I tried to make it a bit nicer with a base class doing the job.